### PR TITLE
configure.ac: fix GEO_NORMALIZE_DISABLE_TOWGS84 definition

### DIFF
--- a/libgeotiff/configure.ac
+++ b/libgeotiff/configure.ac
@@ -322,7 +322,7 @@ fi
 AC_SUBST(PROJ_INCLUDE)
 
 
-AC_ARG_ENABLE(towgs84, [  --disable-towgs84       Disable WGS84 parameters for binary compatibility with pre-1.4.1], AC_DEFINE(GEO_NORMALIZE_DISABLE_TOWGS84))
+AC_ARG_ENABLE(towgs84, [  --disable-towgs84       Disable WGS84 parameters for binary compatibility with pre-1.4.1], AC_DEFINE(GEO_NORMALIZE_DISABLE_TOWGS84, [], [Disable WGS84 parameters]))
 
 dnl #########################################################################
 dnl Doxygen settings


### PR DESCRIPTION
Fix "missing template: GEO_NORMALIZE_DISABLE_TOWGS84" error by adding
a non-empty description of GEO_NORMALIZE_DISABLE_TOWGS84 in AC_DEFINE

Retrieve from:
https://git.buildroot.net/buildroot/tree/package/libgeotiff/0002-fix-GEO_NORMALIZE_DISABLE_TOWGS84-define.patch

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>