### PR TITLE
geo_names.c: Silence warning in GetNameFromDatabase

### DIFF
--- a/libgeotiff/geo_names.c
+++ b/libgeotiff/geo_names.c
@@ -127,8 +127,9 @@ static void GetNameFromDatabase(GTIF* gtif,
         const char* pszName = proj_get_name(obj);
         if( pszName )
         {
-            strncpy(pszOut, pszName, nOutSize);
-            pszOut[nOutSize-1] = 0;
+            size_t nToCopy = MIN(strlen(pszName), nOutSize - 1);
+            memcpy(pszOut, pszName, nToCopy);
+            pszOut[nToCopy] = 0;
         }
         proj_destroy(obj);
     }


### PR DESCRIPTION
Comes from https://github.com/OSGeo/gdal/pull/1409/commits/1982bde2f3c7b17960e285be8614a05a89610f97#r270982654.

This is to address a false positive warning from GCC 8:
```
   In function ‘GetNameFromDatabase.isra.1.constprop’,
        inlined from ‘GTIFValueNameEx’ at geo_names.c:212:21:
    geo_names.c:130:13: warning: ‘strncpy’ specified bound 120 equals destination size [-Wstringop-truncation]
                 strncpy(pszOut, pszName, nOutSize);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In function ‘GetNameFromDatabase.isra.1.constprop’,
        inlined from ‘GTIFValueNameEx’ at geo_names.c:193:21:
    geo_names.c:130:13: warning: ‘strncpy’ specified bound 120 equals destination size [-Wstringop-truncation]
                 strncpy(pszOut, pszName, nOutSize);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In function ‘GetNameFromDatabase.isra.1.constprop’,
        inlined from ‘GTIFValueNameEx’ at geo_names.c:198:21:
    geo_names.c:130:13: warning: ‘strncpy’ specified bound 120 equals destination size [-Wstringop-truncation]
                 strncpy(pszOut, pszName, nOutSize);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In function ‘GetNameFromDatabase.isra.1.constprop’,
        inlined from ‘GTIFValueNameEx’ at geo_names.c:188:21:
    geo_names.c:130:13: warning: ‘strncpy’ specified bound 120 equals destination size [-Wstringop-truncation]
                 strncpy(pszOut, pszName, nOutSize);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In function ‘GetNameFromDatabase.isra.1.constprop’,
        inlined from ‘GTIFValueNameEx’ at geo_names.c:206:21:
    geo_names.c:130:13: warning: ‘strncpy’ specified bound 120 equals destination size [-Wstringop-truncation]
                 strncpy(pszOut, pszName, nOutSize);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```