### PR TITLE
add mailing list link to README

### DIFF
--- a/libgeotiff/README
+++ b/libgeotiff/README
@@ -11,6 +11,13 @@ specifications, projection codes and use, see the WWW web page at:
 or the download archive at:
 
    http://download.osgeo.org/geotiff/
+   
+Mailing List
+------------
+
+To ask questions and to follow release announcements, subscribe at:
+
+   https://lists.osgeo.org/mailman/listinfo/geotiff
 
 
 Use of LIBTIFF
@@ -31,7 +38,7 @@ Use of PROJ
 PROJ 6 or later is a required dependency of libgeotiff 1.5 or later.
 The latest version of PROJ can be found at
 
-    https://proj4.org/
+   https://proj4.org/
 
 
 Building LIBGEOTIFF:


### PR DESCRIPTION
 - adds a section for the mailing list (it is missing, and since it was moved to lists.osgeo.org it is not referenced anywhere)