### PR TITLE
enable build in a separate tree from source

### DIFF
--- a/libgeotiff/Makefile.am
+++ b/libgeotiff/Makefile.am
@@ -11,7 +11,7 @@ if TIFF_IS_CONFIG
 TIFF_CFLAGS = @TIFF_INC@ -DHAVE_TIFF=1
 endif
 
-AM_CFLAGS = -I./libxtiff $(PROJ_CFLAGS) $(TIFF_CFLAGS)
+AM_CFLAGS = -I.$(srcdir)/libxtiff $(PROJ_CFLAGS) $(TIFF_CFLAGS)
 
 include_HEADERS =   geotiff.h \
                     geotiffio.h \
@@ -53,7 +53,7 @@ libgeotiff_la_SOURCES = cpl_serv.c \
                         geo_strtod.c \
                         geotiff_proj4.c
 
-libgeotiff_la_LDFLAGS = -version-info 5:1:0
+libgeotiff_la_LDFLAGS = -version-info 5:1:0 ${NOUNDEFINED}
 
 libgeotiff_la_LIBADD = libxtiff/libxtiff.la
 

--- a/libgeotiff/bin/Makefile.am
+++ b/libgeotiff/bin/Makefile.am
@@ -12,7 +12,7 @@ if TIFF_IS_CONFIG
 TIFF_CFLAGS = @TIFF_INC@ -DHAVE_TIFF=1
 endif
 
-AM_CFLAGS = -I../ -I../libxtiff $(TIFF_CFLAGS) @PROJ_INCLUDE@
+AM_CFLAGS = -I../  -I$(srcdir)/.. -I$(srcdir)/../libxtiff $(TIFF_CFLAGS) @PROJ_INCLUDE@
 
 LDADD = ../libgeotiff.la
 

--- a/libgeotiff/configure.ac
+++ b/libgeotiff/configure.ac
@@ -316,7 +316,21 @@ fi
 AC_SUBST(PROJ_INCLUDE)
 
 
-AC_ARG_ENABLE(towgs84, [  --disable-towgs84       Disable WGS84 parameters for binary compatibility with pre-1.4.1], AC_DEFINE(GEO_NORMALIZE_DISABLE_TOWGS84, [], [Disable WGS84 parameters]))
+AC_ARG_ENABLE(towgs84, [  --disable-towgs84       Disable WGS84 parameters for binary compatibility with pre-1.4.1], AC_DEFINE([GEO_NORMALIZE_DISABLE_TOWGS84], [], [Disable WGS84 parameters]))
+
+AC_MSG_CHECKING([if libtool needs -no-undefined flag to build shared libraries])
+case "${host}" in
+   *-*-cygwin* | *-*-mingw*|*-*-aix*)
+    ## Add in the -no-undefined flag to LDFLAGS for libtool.
+    AC_MSG_RESULT([yes])
+    NOUNDEFINED=" -no-undefined"
+    ;;
+  *)
+    ## Don't add in anything.
+    AC_MSG_RESULT([no])
+    ;;
+esac
+AC_SUBST([NOUNDEFINED])
 
 dnl #########################################################################
 dnl Doxygen settings

--- a/libgeotiff/libxtiff/Makefile.am
+++ b/libgeotiff/libxtiff/Makefile.am
@@ -4,7 +4,7 @@ if TIFF_IS_CONFIG
 TIFF_CFLAGS = @TIFF_INC@ -DHAVE_TIFF=1
 endif
 
-AM_CFLAGS = -I../ $(TIFF_CFLAGS) 
+AM_CFLAGS = -I../ -I$(srcdir)/.. $(TIFF_CFLAGS) 
 
 libxtiff_la_SOURCES = xtiff.c
 

--- a/libgeotiff/test/testlistgeo
+++ b/libgeotiff/test/testlistgeo
@@ -217,6 +217,9 @@ mv ${OUT}.tmp ${OUT}
 sed "s/ETRS89-extended/ETRS89/g" < ${TEST_CLI_DIR}/testlistgeo_out.dist > testlistgeo_out.dist.tmp
 
 # do 'diff' with distribution results
+# after cleaning for avoid spurios result due 
+# to different build dir
+sed -e "s/Testing listgeo .*test/Testing listgeo ..\/test/"  -i ${OUT}
 echo "diff ${OUT} with testlistgeo_out.dist"
 diff -u ${OUT} testlistgeo_out.dist.tmp
 if [ $? -ne 0 ] ; then


### PR DESCRIPTION
same as https://github.com/OSGeo/libgeotiff/issues/28

It also include the needed usage of  "-no-undefined"  for Cygwin and other platforms 