### PR TITLE
add GH actions badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![Windows CI](https://github.com/OSGeo/libgeotiff/workflows/Windows%20CI/badge.svg)
 [![Travis Status](https://travis-ci.org/OSGeo/libgeotiff.svg?branch=master)](https://travis-ci.org/OSGeo/libgeotiff)
 [![Appveyor Status](https://ci.appveyor.com/api/projects/status/github/OSGeo/libgeotiff?svg=true)](https://ci.appveyor.com/project/OSGeo/libgeotiff/branch/master)
 [![Release Version](https://img.shields.io/github/release/OSGeo/libgeotiff)](https://github.com/OSGeo/libgeotiff/releases)


### PR DESCRIPTION
add badge to README showing GitHub Windows CI status after 8affd74cee126f56ba9d646c805e325bd07d3fef