### PR TITLE
geotiff.h: more precise signature for GTIFDirectoryInfo()

### DIFF
--- a/libgeotiff/geotiff.h
+++ b/libgeotiff/geotiff.h
@@ -131,7 +131,7 @@ GTIF GTIF_DLL *GTIFNewWithMethodsEx(void *tif, TIFFMethod* methods,
 void GTIF_DLL  GTIFFree(GTIF *gtif);
 int  GTIF_DLL  GTIFWriteKeys(GTIF *gtif);
 /* versions must be an array of 3 int */
-void GTIF_DLL  GTIFDirectoryInfo(GTIF *gtif, int *versions, int *keycount);
+void GTIF_DLL  GTIFDirectoryInfo(GTIF *gtif, int versions[3], int *keycount);
 void GTIF_DLL *GTIFGetUserData(GTIF *gtif);
 int  GTIF_DLL  GTIFSetVersionNumbers(GTIF* gtif,
                                      unsigned short version,


### PR DESCRIPTION
Fixes following warning with recent gcc versions:
 warning: argument 2 of type 'int[3]' with mismatched bound [-Warray-parameter=]