### PR TITLE
geo_config.h: prefix HAVE_xxx and restrict it to GEOTIFF_HAVE_STRINGS_H (fixes #61)

### DIFF
--- a/libgeotiff/CMakeLists.txt
+++ b/libgeotiff/CMakeLists.txt
@@ -103,10 +103,7 @@ ENDIF()
 
 # Check required standard headers
 INCLUDE(CheckIncludeFiles)
-CHECK_INCLUDE_FILES(stdio.h HAVE_STDIO_H)
-CHECK_INCLUDE_FILES(stdlib.h HAVE_STDLIB_H)
-CHECK_INCLUDE_FILES(string.h HAVE_STRING_H)
-CHECK_INCLUDE_FILES(strings.h HAVE_STRINGS_H)
+CHECK_INCLUDE_FILES(strings.h GEOTIFF_HAVE_STRINGS_H)
 
 ###############################################################################
 # User-defined build settings

--- a/libgeotiff/cmake/geo_config.h.in
+++ b/libgeotiff/cmake/geo_config.h.in
@@ -1,14 +1,8 @@
 #ifndef GEO_CONFIG_H
 #define GEO_CONFIG_H
 
-/* Define if you have the <stdlib.h> header file.  */
-#cmakedefine HAVE_STDLIB_H
-
-/* Define if you have the <string.h> header file.  */
-#cmakedefine HAVE_STRING_H
-
 /* Define if you have the <strings.h> header file.  */
-#cmakedefine HAVE_STRINGS_H
+#cmakedefine GEOTIFF_HAVE_STRINGS_H 1
 
 #cmakedefine GEO_NORMALIZE_DISABLE_TOWGS84
 

--- a/libgeotiff/configure.ac
+++ b/libgeotiff/configure.ac
@@ -45,7 +45,11 @@ dnl #########################################################################
 dnl Checks for header files.
 dnl #########################################################################
 
-AC_CHECK_HEADERS([string.h],[HAVE_STRING_H=1], [AC_MSG_ERROR([cannot find string.h, bailing out])])
+dnl AC_CHECK_HEADERS([string.h],[HAVE_STRING_H=1], [AC_MSG_ERROR([cannot find string.h, bailing out])])
+AC_CHECK_HEADERS([strings.h],[GEOTIFF_HAVE_STRINGS_H=1])
+AC_DEFINE_UNQUOTED(GEOTIFF_HAVE_STRINGS_H, 1,
+          [Define if you have the <strings.h> header file.])
+
 AC_CHECK_HEADERS([stdio.h],, [AC_MSG_ERROR([cannot find stdio.h, bailing out])])
 AC_CHECK_HEADERS([stdlib.h],, [AC_MSG_ERROR([cannot find stdlib.h, bailing out])])
 

--- a/libgeotiff/cpl_serv.h
+++ b/libgeotiff/cpl_serv.h
@@ -38,15 +38,11 @@
 
 #include <math.h>
 
-#ifdef HAVE_STRING_H
-#  include <string.h>
-#endif
-#if defined(HAVE_STRINGS_H) && !defined(_WIN32)
+#include <string.h>
+#if defined(GEOTIFF_HAVE_STRINGS_H) && !defined(_WIN32)
 #  include <strings.h>
 #endif
-#ifdef HAVE_STDLIB_H
-#  include <stdlib.h>
-#endif
+#include <stdlib.h>
 
 /**********************************************************************
  * Do we want to build as a DLL on windows?

--- a/libgeotiff/geo_config.h.in
+++ b/libgeotiff/geo_config.h.in
@@ -1,20 +1,8 @@
 #ifndef GEO_CONFIG_H
 #define GEO_CONFIG_H
 
-/* Define if you have the ANSI C header files.  */
-#undef STDC_HEADERS
-
-/* Define if you have the <stdlib.h> header file.  */
-#undef HAVE_STDLIB_H
-
-/* Define if you have the <string.h> header file.  */
-#undef HAVE_STRING_H
-
 /* Define if you have the <strings.h> header file.  */
-#undef HAVE_STRINGS_H
-
-#undef HAVE_LIBPROJ
-#undef HAVE_PROJECTS_H
+#undef GEOTIFF_HAVE_STRINGS_H
 
 #undef GEO_NORMALIZE_DISABLE_TOWGS84
 


### PR DESCRIPTION
- Avoid collision with other packages such as GDAL
- No longer test basic C headers. If there are not there, the build
system is highly broken.