### PR TITLE
Revise exported CMake config

### DIFF
--- a/libgeotiff/CMakeLists.txt
+++ b/libgeotiff/CMakeLists.txt
@@ -328,19 +328,20 @@ endif()
 SET_TARGET_PROPERTIES(${GEOTIFF_LIBRARY_TARGET} PROPERTIES
    OUTPUT_NAME ${GEOTIFF_LIB_NAME})
 
+set(CONFIG_DEPENDENCIES "")
 if(TARGET TIFF::TIFF)
-target_link_libraries(${GEOTIFF_LIBRARY_TARGET} PUBLIC TIFF::TIFF)
-else()
+    set(TIFF_LIBRARIES TIFF::TIFF)
+    string(APPEND CONFIG_DEPENDENCIES "  find_dependency(TIFF)\n")
+endif()
 target_link_libraries(${GEOTIFF_LIBRARY_TARGET} PUBLIC
     ${TIFF_LIBRARIES})
-endif()
 
 if(TARGET PROJ::proj)
-target_link_libraries(${GEOTIFF_LIBRARY_TARGET} PRIVATE PROJ::proj)
-else()
+    set(PROJ_LIBRARIES PROJ::proj)
+    string(APPEND CONFIG_DEPENDENCIES "  find_dependency(PROJ CONFIG)\n")
+endif()
 target_link_libraries(${GEOTIFF_LIBRARY_TARGET} PRIVATE
     ${PROJ_LIBRARIES})
-endif()
 
 target_include_directories(
   ${GEOTIFF_LIBRARY_TARGET}

--- a/libgeotiff/cmake/project-config.cmake.in
+++ b/libgeotiff/cmake/project-config.cmake.in
@@ -13,11 +13,6 @@
 # @PROJECT_NAME_UPPER@_LIBRARY
 # @PROJECT_NAME_UPPER@_LIBRARIES
 
-message (STATUS "Reading ${CMAKE_CURRENT_LIST_FILE}")
-# @PROJECT_NAME@_VERSION is set by version file
-message (STATUS
-  "@PROJECT_NAME@ configuration, version ${@PROJECT_NAME@_VERSION}")
-
 # Tell the user project where to find our headers and libraries
 get_filename_component (_DIR ${CMAKE_CURRENT_LIST_FILE} PATH)
 get_filename_component (_ROOT "${_DIR}/@PROJECT_ROOT_DIR@" ABSOLUTE)
@@ -27,17 +22,26 @@ set (@PROJECT_NAME@_BINARY_DIRS "${_ROOT}/bin")
 unset (_ROOT)
 unset (_DIR)
 
-message (STATUS "  include directory: \${@PROJECT_NAME@_INCLUDE_DIRS}")
-
 set (@PROJECT_NAME@_LIBRARIES @GEOTIFF_LIBRARY_TARGET@)
 if("@BUILD_SHARED_LIBS@")
-  message (STATUS "  \${@PROJECT_NAME@_LIBRARIES} set to shared library")
   set (@PROJECT_NAME@_SHARED_LIBRARIES ${@PROJECT_NAME@_LIBRARIES})
 else()
-  message (STATUS "  \${@PROJECT_NAME@_LIBRARIES} set to static libraries")
   set (@PROJECT_NAME@_STATIC_LIBRARIES ${@PROJECT_NAME@_LIBRARIES})
   include(CMakeFindDependencyMacro)
 @CONFIG_DEPENDENCIES@
+endif()
+
+if(NOT @PROJECT_NAME@_FIND_QUIETLY)
+  message (STATUS "Reading ${CMAKE_CURRENT_LIST_FILE}")
+  # @PROJECT_NAME@_VERSION is set by version file
+  message (STATUS
+    "@PROJECT_NAME@ configuration, version ${@PROJECT_NAME@_VERSION}")
+  message (STATUS "  include directory: \${@PROJECT_NAME@_INCLUDE_DIRS}")
+  if("@BUILD_SHARED_LIBS@")
+    message (STATUS "  \${@PROJECT_NAME@_LIBRARIES} set to shared library")
+  else()
+    message (STATUS "  \${@PROJECT_NAME@_LIBRARIES} set to static libraries")
+  endif()
 endif()
 
 # Read in the exported definition of the library

--- a/libgeotiff/cmake/project-config.cmake.in
+++ b/libgeotiff/cmake/project-config.cmake.in
@@ -3,14 +3,9 @@
 # Set
 #  @PROJECT_NAME@_FOUND = 1
 #  @PROJECT_NAME@_INCLUDE_DIRS = /usr/local/include
-#  @PROJECT_NAME@_SHARED_LIBRARIES = geotiff_library
-#  @PROJECT_NAME@_STATIC_LIBRARIES = geotiff_archive
 #  @PROJECT_NAME@_LIBRARY_DIRS = /usr/local/lib
 #  @PROJECT_NAME@_BINARY_DIRS = /usr/local/bin
 #  @PROJECT_NAME@_VERSION = 1.4.1 (for example)
-#  Depending on @PROJECT_NAME@_USE_STATIC_LIBS
-#    @PROJECT_NAME@_LIBRARIES = ${@PROJECT_NAME@_SHARED_LIBRARIES}, if OFF
-#    @PROJECT_NAME@_LIBRARIES = ${@PROJECT_NAME@_STATIC_LIBRARIES}, if ON
 
 # For compatibility with FindGeoTIFF.cmake, also set
 # @PROJECT_NAME_UPPER@_FOUND
@@ -29,27 +24,22 @@ get_filename_component (_ROOT "${_DIR}/@PROJECT_ROOT_DIR@" ABSOLUTE)
 set (@PROJECT_NAME@_INCLUDE_DIRS "${_ROOT}/include")
 set (@PROJECT_NAME@_LIBRARY_DIRS "${_ROOT}/lib")
 set (@PROJECT_NAME@_BINARY_DIRS "${_ROOT}/bin")
-
-message (STATUS "  include directory: \${@PROJECT_NAME@_INCLUDE_DIRS}")
-
-if(BUILD_SHARED_LIBS)
-set (@PROJECT_NAME@_SHARED_LIBRARIES @GEOTIFF_LIBRARY_TARGET@)
-else()
-set (@PROJECT_NAME@_STATIC_LIBRARIES @GEOTIFF_LIBRARY_TARGET@)
-endif()
-# Read in the exported definition of the library
-include ("${_DIR}/@PROJECT_NAME_LOWER@-depends.cmake")
-
 unset (_ROOT)
 unset (_DIR)
 
-if (@PROJECT_NAME@_USE_STATIC_LIBS)
-  set (@PROJECT_NAME@_LIBRARIES ${@PROJECT_NAME@_STATIC_LIBRARIES})
-  message (STATUS "  \${@PROJECT_NAME@_LIBRARIES} set to static library")
-else ()
-  set (@PROJECT_NAME@_LIBRARIES ${@PROJECT_NAME@_SHARED_LIBRARIES})
+message (STATUS "  include directory: \${@PROJECT_NAME@_INCLUDE_DIRS}")
+
+set (@PROJECT_NAME@_LIBRARIES @GEOTIFF_LIBRARY_TARGET@)
+if("@BUILD_SHARED_LIBS@")
   message (STATUS "  \${@PROJECT_NAME@_LIBRARIES} set to shared library")
-endif ()
+  set (@PROJECT_NAME@_SHARED_LIBRARIES ${@PROJECT_NAME@_LIBRARIES})
+else()
+  message (STATUS "  \${@PROJECT_NAME@_LIBRARIES} set to static libraries")
+  set (@PROJECT_NAME@_STATIC_LIBRARIES ${@PROJECT_NAME@_LIBRARIES})
+endif()
+
+# Read in the exported definition of the library
+include ("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME_LOWER@-depends.cmake")
 
 # For compatibility with FindGeoTIFF.cmake
 set (@PROJECT_NAME_UPPER@_FOUND 1)

--- a/libgeotiff/cmake/project-config.cmake.in
+++ b/libgeotiff/cmake/project-config.cmake.in
@@ -36,6 +36,8 @@ if("@BUILD_SHARED_LIBS@")
 else()
   message (STATUS "  \${@PROJECT_NAME@_LIBRARIES} set to static libraries")
   set (@PROJECT_NAME@_STATIC_LIBRARIES ${@PROJECT_NAME@_LIBRARIES})
+  include(CMakeFindDependencyMacro)
+@CONFIG_DEPENDENCIES@
 endif()
 
 # Read in the exported definition of the library


### PR DESCRIPTION
While testing 1.7.1 RC1, I found these issues with the exported cmake config:
- It uses some `@PROJECT_NAME@_USE_STATIC_LIBS` and the `BUILD_SHARED_LIBS` value when the config is consumed, but the available linkage is determined at build time.
- `@PROJECT_NAME@_SHARED_LIBRARIES` and `@PROJECT_NAME@_STATIC_LIBRARIES` shouldn't be advertised IMO. Linkage is determined at build time. The variables are either empty or `libgeotiff`.
- For static linkage, the config must care for the dependencies expressed in targets.
- The config was verbose even when the user passes `QUIET` to `find_package`.

This is adressed in PR, but not yet tested thoroughly.

Other isssue which are not adressed:
- If there is a desire for `@PROJECT_NAME@_USE_STATIC_LIBS`, a non-matching config should do nothing, giving other configs the chance to be considered by CMake.
