### PR TITLE
TIFF_LIBRARIES are private

### DIFF
--- a/libgeotiff/CMakeLists.txt
+++ b/libgeotiff/CMakeLists.txt
@@ -335,7 +335,7 @@ if(TARGET TIFF::TIFF)
     set(TIFF_LIBRARIES TIFF::TIFF)
     string(APPEND CONFIG_DEPENDENCIES "  find_dependency(TIFF)\n")
 endif()
-target_link_libraries(${GEOTIFF_LIBRARY_TARGET} PUBLIC
+target_link_libraries(${GEOTIFF_LIBRARY_TARGET} PRIVATE
     ${TIFF_LIBRARIES})
 
 if(TARGET PROJ::proj)

--- a/libgeotiff/bin/CMakeLists.txt
+++ b/libgeotiff/bin/CMakeLists.txt
@@ -16,22 +16,16 @@ ENDIF()
 ###############################################################################
 # Collect programs to build
 
-SET(GEOTIFF_UTILITIES makegeo listgeo applygeo)
+SET(GEOTIFF_UTILITIES makegeo listgeo applygeo geotifcp)
 
 MESSAGE(STATUS "Adding GeoTIFF utilities to build")
 
 FOREACH(utility ${GEOTIFF_UTILITIES})
     ADD_EXECUTABLE(${utility} ${utility}.c ${GETOPT_SOURCE})
-    TARGET_LINK_LIBRARIES(${utility} PRIVATE xtiff ${GEOTIFF_LIBRARY_TARGET})
+    TARGET_LINK_LIBRARIES(${utility} PRIVATE xtiff ${GEOTIFF_LIBRARY_TARGET} ${TIFF_LIBRARIES})
 ENDFOREACH()
 
-ADD_EXECUTABLE(geotifcp geotifcp.c ${GETOPT_SOURCE})
-TARGET_LINK_LIBRARIES(geotifcp
-    PRIVATE
-    xtiff
-    ${GEOTIFF_LIBRARY_TARGET}
-    ${JPEG_LIBRARIES}
-    ${ZLIB_LIBRARIES})
+TARGET_LINK_LIBRARIES(geotifcp PRIVATE ${JPEG_LIBRARIES} ${ZLIB_LIBRARIES})
 
 SET(GEOTIFF_UTILITIES ${GEOTIFF_UTILITIES} geotifcp )
 


### PR DESCRIPTION
The public linkage of `TIFF_LIBRARIES` exposes TIFF to downstream compilation stages, even when linking to the shared libgeotiff. This isn't needed, and the exposure of `TIFF::TIFF` in dynamic builds is not handled in the exported CMake config.