### PR TITLE
Add XTIFFClientOpenExt() with re-entrant error callbacks

### DIFF
--- a/libgeotiff/libxtiff/xtiff.c
+++ b/libgeotiff/libxtiff/xtiff.c
@@ -188,6 +188,68 @@ XTIFFClientOpen(const char* name, const char* mode, thandle_t thehandle,
     return tif;
 }
 
+#ifdef HAVE_TIFFClientOpenExt
+
+TIFF*
+XTIFFOpenExt(const char* name, const char* mode, TIFFOpenOptions* opts)
+{
+    TIFF *tif;
+
+    /* Set up the callback */
+    XTIFFInitialize();
+
+    /* Open the file; the callback will set everything up
+     */
+    tif = TIFFOpenExt(name, mode, opts);
+    if (!tif) return tif;
+
+    return tif;
+}
+
+TIFF*
+XTIFFFdOpenExt(int fd, const char* name, const char* mode, TIFFOpenOptions* opts)
+{
+    TIFF *tif;
+
+    /* Set up the callback */
+    XTIFFInitialize();
+
+    /* Open the file; the callback will set everything up
+     */
+    tif = TIFFFdOpenExt(fd, name, mode, opts);
+    if (!tif) return tif;
+
+    return tif;
+}
+
+TIFF*
+XTIFFClientOpenExt(const char* name, const char* mode, thandle_t thehandle,
+                   TIFFReadWriteProc RWProc, TIFFReadWriteProc RWProc2,
+                   TIFFSeekProc SProc, TIFFCloseProc CProc,
+                   TIFFSizeProc SzProc,
+                   TIFFMapFileProc MFProvc, TIFFUnmapFileProc UMFProc,
+                   TIFFOpenOptions* opts)
+{
+    TIFF *tif;
+
+    /* Set up the callback */
+    XTIFFInitialize();
+
+    /* Open the file; the callback will set everything up
+     */
+    tif = TIFFClientOpenExt(name, mode, thehandle,
+                            RWProc, RWProc2,
+                            SProc, CProc,
+                            SzProc,
+                            MFProvc, UMFProc,
+                            opts);
+
+    if (!tif) return tif;
+
+    return tif;
+}
+#endif
+
 /**
  * Close a file opened with XTIFFOpen().
  *

--- a/libgeotiff/libxtiff/xtiffio.h
+++ b/libgeotiff/libxtiff/xtiffio.h
@@ -76,6 +76,24 @@ extern TIFF GTIF_DLL * XTIFFClientOpen(const char* name, const char* mode,
                                       TIFFSeekProc, TIFFCloseProc,
                                       TIFFSizeProc,
                                       TIFFMapFileProc, TIFFUnmapFileProc);
+
+#if TIFFLIB_VERSION > 20220520
+/* TIFFClientOpenExt() available in libtiff >= 4.5.0, which is strictly later after 20220520 */
+#define HAVE_TIFFClientOpenExt
+#endif
+
+#ifdef HAVE_TIFFClientOpenExt
+extern TIFF GTIF_DLL * XTIFFOpenExt(const char* name, const char* mode, TIFFOpenOptions* opts);
+extern TIFF GTIF_DLL * XTIFFFdOpenExt(int fd, const char* name, const char* mode, TIFFOpenOptions* opts);
+extern TIFF GTIF_DLL * XTIFFClientOpenExt(const char* name, const char* mode,
+                                          thandle_t thehandle,
+                                          TIFFReadWriteProc, TIFFReadWriteProc,
+                                          TIFFSeekProc, TIFFCloseProc,
+                                          TIFFSizeProc,
+                                          TIFFMapFileProc, TIFFUnmapFileProc,
+                                          TIFFOpenOptions* opts);
+#endif
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
Depends on https://gitlab.com/libtiff/libtiff/-/merge_requests/413