### PR TITLE
.appveyor.yml: Pin vcpkg version to avoid cmake install bug

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,8 @@ build_script:
 # Build vcpkg
   - git clone https://github.com/microsoft/vcpkg
   - cd vcpkg
+  # Remove this after this is fixed: https://github.com/microsoft/vcpkg/issues/33904
+  - git checkout 2023.08.09
   - bootstrap-vcpkg.bat
   - set PATH=%CD%;%PATH%
   - cd ..


### PR DESCRIPTION
https://github.com/microsoft/vcpkg/issues/33904

Should fix https://github.com/OSGeo/libgeotiff/issues/94