### PR TITLE
Fix FTBFS with GCC 15.

### DIFF
--- a/libgeotiff/bin/geotifcp.c
+++ b/libgeotiff/bin/geotifcp.c
@@ -37,7 +37,7 @@
 #define	TRUE	1
 #define	FALSE	0
 
-int getopt();
+int getopt(int nargc, char** nargv, char* ostr);
 
 static  int outtiled = -1;
 static  uint32_t tilewidth;


### PR DESCRIPTION
As reported in [Debian Bug #1097191](https://bugs.debian.org/), libgeotiff fails to build with GCC 15:
```
geotifcp.c: In function ‘main’:
geotifcp.c:114:21: error: too many arguments to function ‘getopt’; expected 0, have 3
  114 |         while ((c = getopt(argc, argv, "c:f:l:o:p:r:w:e:g:4:v:aistd8BLMC")) != -1)
      |                     ^~~~~~ ~~~~
geotifcp.c:40:5: note: declared here
   40 | int getopt();
      |     ^~~~~~
```
See also: https://gcc.gnu.org/gcc-15/porting_to.html#c23-fn-decls-without-parameters