### PR TITLE
geo_simpletags.c: Cleanup headers.

### DIFF
--- a/libgeotiff/geo_simpletags.c
+++ b/libgeotiff/geo_simpletags.c
@@ -25,11 +25,13 @@
  *
  *****************************************************************************/
 
+#include <stdlib.h>
+#include <string.h>
+
 #include "geotiff.h"    /* public GTIFF interface */
 #include "geo_simpletags.h"
 
 #include "geo_tiffp.h"  /* Private TIFF interface */
-#include "geo_keyp.h"   /* Private GTIFF interface */
 
 static int ST_TypeSize( int st_type );
 


### PR DESCRIPTION
- Add stdlib.h for calloc, free, and malloc
- Add string.h for memcpy and strlen
- Removed unused geo_keyp.h. It was being used for the above 2 includes