### PR TITLE
avoid C4996 warning on MSVC for utilities

### DIFF
--- a/libgeotiff/bin/CMakeLists.txt
+++ b/libgeotiff/bin/CMakeLists.txt
@@ -13,12 +13,6 @@ INCLUDE_DIRECTORIES(
 IF(WIN32 AND MSVC)
     SET(GETOPT_SOURCE getopt.c)
 ENDIF()
-
-# avoid warnings of "This function or variable may be unsafe"
-if(MSVC)
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-endif()
-
 ###############################################################################
 # Collect programs to build
 

--- a/libgeotiff/bin/CMakeLists.txt
+++ b/libgeotiff/bin/CMakeLists.txt
@@ -36,6 +36,9 @@ TARGET_LINK_LIBRARIES(geotifcp
     ${JPEG_LIBRARIES}
     ${ZLIB_LIBRARIES})
 target_include_directories(geotifcp PRIVATE $<TARGET_PROPERTY:${PROJ_LIBRARIES},INTERFACE_INCLUDE_DIRECTORIES>)
+if(MSVC)
+    target_compile_definitions(geotifcp PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+endif()
 
 SET(GEOTIFF_UTILITIES ${GEOTIFF_UTILITIES} geotifcp )
 

--- a/libgeotiff/bin/CMakeLists.txt
+++ b/libgeotiff/bin/CMakeLists.txt
@@ -29,6 +29,21 @@ MESSAGE(STATUS "Adding GeoTIFF utilities to build")
 FOREACH(utility ${GEOTIFF_UTILITIES})
     ADD_EXECUTABLE(${utility} ${utility}.c ${GETOPT_SOURCE})
     TARGET_LINK_LIBRARIES(${utility} PRIVATE ${GEOTIFF_LIBRARY_TARGET})
+
+###############################################################################
+# Collect programs to build
+
+SET(GEOTIFF_UTILITIES makegeo listgeo applygeo)
+
+MESSAGE(STATUS "Adding GeoTIFF utilities to build")
+
+FOREACH(utility ${GEOTIFF_UTILITIES})
+   ADD_EXECUTABLE(${utility} ${utility}.c ${GETOPT_SOURCE})
+   TARGET_LINK_LIBRARIES(${utility} PRIVATE ${GEOTIFF_LIBRARY_TARGET})
+   # avoid warnings of "This function or variable may be unsafe"
+   if(MSVC)
+        target_compile_definitions(${utility} PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+   endif()
 ENDFOREACH()
 
 ADD_EXECUTABLE(geotifcp geotifcp.c ${GETOPT_SOURCE})

--- a/libgeotiff/bin/CMakeLists.txt
+++ b/libgeotiff/bin/CMakeLists.txt
@@ -13,6 +13,12 @@ INCLUDE_DIRECTORIES(
 IF(WIN32 AND MSVC)
     SET(GETOPT_SOURCE getopt.c)
 ENDIF()
+
+# avoid warnings of "This function or variable may be unsafe"
+if(MSVC)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+endif()
+
 ###############################################################################
 # Collect programs to build
 

--- a/libgeotiff/bin/CMakeLists.txt
+++ b/libgeotiff/bin/CMakeLists.txt
@@ -23,21 +23,10 @@ MESSAGE(STATUS "Adding GeoTIFF utilities to build")
 FOREACH(utility ${GEOTIFF_UTILITIES})
     ADD_EXECUTABLE(${utility} ${utility}.c ${GETOPT_SOURCE})
     TARGET_LINK_LIBRARIES(${utility} PRIVATE ${GEOTIFF_LIBRARY_TARGET})
-
-###############################################################################
-# Collect programs to build
-
-SET(GEOTIFF_UTILITIES makegeo listgeo applygeo)
-
-MESSAGE(STATUS "Adding GeoTIFF utilities to build")
-
-FOREACH(utility ${GEOTIFF_UTILITIES})
-   ADD_EXECUTABLE(${utility} ${utility}.c ${GETOPT_SOURCE})
-   TARGET_LINK_LIBRARIES(${utility} PRIVATE ${GEOTIFF_LIBRARY_TARGET})
-   # avoid warnings of "This function or variable may be unsafe"
-   if(MSVC)
+    # avoid warnings of "This function or variable may be unsafe"
+    if(MSVC)
         target_compile_definitions(${utility} PRIVATE -D_CRT_SECURE_NO_WARNINGS)
-   endif()
+    endif()
 ENDFOREACH()
 
 ADD_EXECUTABLE(geotifcp geotifcp.c ${GETOPT_SOURCE})


### PR DESCRIPTION
- using `master` with MSVC 2022 gives the following warnings:
```
[ 71%] Building C object bin/CMakeFiles/listgeo.dir/listgeo.c.obj
listgeo.c
\libgeotiff\bin\listgeo.c(280): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
\libgeotiff\bin\listgeo.c(286): warning C4996: 'strcat': This function or variable may be unsafe. Consider using strcat_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
\libgeotiff\bin\listgeo.c(274): warning C4996: 'strncpy': This function or variable may be unsafe. Consider using strncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
[ 75%] Building C object bin/CMakeFiles/listgeo.dir/getopt.c.obj
getopt.c
[ 78%] Linking C executable listgeo.exe
[ 78%] Built target listgeo
[ 82%] Building C object bin/CMakeFiles/applygeo.dir/applygeo.c.obj
applygeo.c
[ 85%] Building C object bin/CMakeFiles/applygeo.dir/getopt.c.obj
getopt.c
[ 89%] Linking C executable applygeo.exe
[ 89%] Built target applygeo
[ 92%] Building C object bin/CMakeFiles/geotifcp.dir/geotifcp.c.obj
geotifcp.c
\libgeotiff\bin\geotifcp.c(252): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
\libgeotiff\bin\geotifcp.c(253): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
\libgeotiff\bin\geotifcp.c(254): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
\libgeotiff\bin\geotifcp.c(255): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
\libgeotiff\bin\geotifcp.c(256): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
\libgeotiff\bin\geotifcp.c(257): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
\libgeotiff\bin\geotifcp.c(317): warning C4996: 'fopen': This function or variable may be unsafe. Consider using fopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
\libgeotiff\bin\geotifcp.c(484): warning C4996: 'setbuf': This function or variable may be unsafe. Consider using setvbuf instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
[ 96%] Building C object bin/CMakeFiles/geotifcp.dir/getopt.c.obj
getopt.c
[100%] Linking C executable geotifcp.exe
[100%] Built target geotifcp
```
- this PR sets `-D_CRT_SECURE_NO_WARNINGS` in the /bin `CMakeLists.txt` (which is already set in the root `CMakeLists.txt`)