### PR TITLE
libgeotiff/CMakeLists: Propegate proj usage requirements publically

### DIFF
--- a/libgeotiff/CMakeLists.txt
+++ b/libgeotiff/CMakeLists.txt
@@ -340,8 +340,8 @@ if(TARGET ZLIB::zlib)
     string(APPEND CONFIG_PRIVATE_DEPENDENCIES "  find_dependency(ZLIB)\n")
 endif()
 
+target_link_libraries(${GEOTIFF_LIBRARY_TARGET} PUBLIC ${PROJ_LIBRARIES})
 target_link_libraries(${GEOTIFF_LIBRARY_TARGET} PRIVATE
-                      ${PROJ_LIBRARIES}
                       ${TIFF_LIBRARIES}
                       ${ZLIB_LIBRARIES})
 


### PR DESCRIPTION
geo_keyp.h is a public header that includes proj.h, so PROJ must be a PUBLIC cmake dependency so that downstream targets (utilities, consumers) can find proj.h.

See https://github.com/spack/spack-packages/pull/5368 for the use and testing of this patch (tested on MacOs, Linux, and Windows)